### PR TITLE
Remove node14 support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.2.2",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
-        "@tsconfig/node14": "^1.0.3",
+        "@tsconfig/node16": "^1.0.3",
         "@types/glob": "^8.0.0",
         "@types/jest": "^29.0.0",
         "@types/node": "^20.1.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "types": "dist/index.d.ts",
   "type": "commonjs",
   "devDependencies": {
-    "@tsconfig/node14": "^1.0.3",
+    "@tsconfig/node16": "^1.0.3",
     "@types/glob": "^8.0.0",
     "@types/jest": "^29.0.0",
     "@types/node": "^20.1.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "outDir": "dist",
     "module": "CommonJS",


### PR DESCRIPTION
Updates typescript to target node16 instead of node14 - this is because node14 has reached end of life.